### PR TITLE
Updating dataflow: DF_FactTbl_Speedbumps_Quarter

### DIFF
--- a/dataflow/DF_FactTbl_Speedbumps_Quarter.json
+++ b/dataflow/DF_FactTbl_Speedbumps_Quarter.json
@@ -1181,6 +1181,7 @@
 				"     skipDuplicateMapOutputs: true) ~> SelectInactiveSpeedbumpRows",
 				"CombinedWithUnionTerms, SelectInactiveSpeedbumpRows union(byName: true)~> union1",
 				"SelectTermRecords aggregate(groupBy({Client ID},",
+				"          {Client Engagement Date},",
 				"          EventId,",
 				"          {Worker ID}),",
 				"     EventDt = max(EventDt),",


### PR DESCRIPTION
Fix issue in quarterly speedbumps where the engagement date is missing for terminated baseline employees that come into the quarterly data.