### PR TITLE
Etalent scott

### DIFF
--- a/dataflow/DF_FactTbl_Speedbumps_Baseline.json
+++ b/dataflow/DF_FactTbl_Speedbumps_Baseline.json
@@ -723,7 +723,7 @@
 				"          {Speedbump 3 Flag} = iif(isNull({Mgr Worker ID}),'N',iif({Years of Service}>={Mgr Years of Service},'Y','N')),",
 				"          {Speedbump 4 Name} = 'Promotion History',",
 				"          {Speedbump 4 Desc} = 'Have not been promoted (normally this is in the last 3 years to coincide with the promo data we are provided)',",
-				"          {Speedbump 4 Flag} = iif({Curr Promo}=='Y','N',iif({P1 Promo}=='Y','N',iif({P2 Promo}=='Y','N',iif({P3 Promo}=='Y','N',iif(isNull(CoreLastPromoDt),'Y',iif(year(CoreLastPromoDt)>=toInteger($SB_BL_Year),'N','Y')))))),",
+				"          {Speedbump 4 Flag} = iif({Elloree Corporate Title Sort}==1, 'N',iif({Curr Promo}=='Y','N',iif({P1 Promo}=='Y','N',iif({P2 Promo}=='Y','N',iif(isNull(CoreLastPromoDt),'Y',iif(year(CoreLastPromoDt)>=toInteger($SB_BL_Year)-2,'N','Y')))))),",
 				"          {Speedbump 5 Name} = 'Applied Roles',",
 				"          {Speedbump 5 Desc} = 'Employee applied for 5 or more roles in the current year',",
 				"          {Speedbump 5 Flag} = iif({Applicant Five or More}=='Y','Y','N'),",

--- a/dataflow/DF_FactTbl_Speedbumps_Quarter.json
+++ b/dataflow/DF_FactTbl_Speedbumps_Quarter.json
@@ -886,7 +886,7 @@
 				"          {Speedbump 3 Flag} = iif(isNull({Mgr Worker ID}),'N',iif({Years of Service}>={Mgr Years of Service},'Y','N')),",
 				"          {Speedbump 4 Name} = 'Promotion History',",
 				"          {Speedbump 4 Desc} = 'Have not been promoted (normally this is in the last 3 years to coincide with the promo data we are provided)',",
-				"          {Speedbump 4 Flag} = iif({Curr Promo}=='Y','N',iif({P1 Promo}=='Y','N',iif({P2 Promo}=='Y','N',iif({P3 Promo}=='Y','N',iif(year(CoreLastPromoDt)>=toInteger($SB_BL_Year),'N','Y'))))),",
+				"          {Speedbump 4 Flag} = iif({Elloree Corporate Title Sort}==1, 'N',iif({Curr Promo}=='Y','N',iif({P1 Promo}=='Y','N',iif({P2 Promo}=='Y','N',iif(isNull(CoreLastPromoDt),'Y',iif(year(CoreLastPromoDt)>=toInteger($SB_BL_Year)-2,'N','Y')))))),",
 				"          {Speedbump 5 Name} = 'Applied Roles',",
 				"          {Speedbump 5 Desc} = 'Employee applied for 5 or more roles in the current year',",
 				"          {Speedbump 5 Flag} = iif({Applicant Five or More}=='Y','Y','N'),",


### PR DESCRIPTION
Made adjustments to the promotion speedbump to only pull promotions in Curr event year and prior 2 event years.  Additionally will flag promotion speedbumps as 'N' for highest level executives.