### PR TITLE
Updating dataflow: DF_FactTbl_Speedbumps_BL_wParam_Bamboo

### DIFF
--- a/dataflow/DF_FactTbl_Speedbumps_BL_wParam_Bamboo.json
+++ b/dataflow/DF_FactTbl_Speedbumps_BL_wParam_Bamboo.json
@@ -635,7 +635,7 @@
 				"     allowSchemaDrift: true,",
 				"     validateSchema: false,",
 				"     isolationLevel: 'READ_UNCOMMITTED',",
-				"     query: (\"select * from [dbo].[TalentFactTbl] where ClientId = '{$Flow_Client_Id}' and ClientEngagementDt = '{$Flow_Client_Dt}'\"),",
+				"     query: (\"select * from [dbo].[TalentFactTbl] where ClientId = '{$Flow_Client_Id}' and ClientEngagementDt = '{$Flow_Client_Dt}' and EventYear = '{$SB_BL_Year}'\"),",
 				"     format: 'query') ~> Talent",
 				"CoreFact, SelectEmpTalentTag join(WorkerId == {Emp Perf Rating Worker ID}",
 				"     && EventYear == {Emp Perf Rating Event Year},",


### PR DESCRIPTION
Using Baseline Year in the Talent table pull in order to eliminate multiple years which is causing issue in the Join back to Core.